### PR TITLE
fix(test): Deallocate Wasm memory after test execution

### DIFF
--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -48,7 +48,14 @@ pub fn run(vp_path: PathBuf, intent_path: PathBuf) -> Result<()> {
     // 8. Call the `validate_intent` function
     let result_code = validate_intent_func.call(&mut store, (intent_ptr, intent_len))?;
 
-    // 9. Interpret and print the result
+    // 9. Deallocate the memory in the Wasm instance
+    let wasm_dealloc = instance
+        .get_typed_func::<(i32, i32), ()>(&mut store, "wasm_dealloc")
+        .context("Failed to find 'wasm_dealloc' function export. Ensure your VP template has it.")?;
+
+    wasm_dealloc.call(&mut store, (intent_ptr, intent_len))?;
+
+    // 10. Interpret and print the result
     let is_valid = result_code != 0;
 
     if is_valid {


### PR DESCRIPTION
The `test` command was allocating memory within the Wasm guest instance to pass the intent data, but it was not deallocating this memory after the `validate_intent` function was executed. This caused a memory leak within the Wasm instance for each test run.

This commit fixes the leak by adding a call to the `wasm_dealloc` function, which is expected to be exported by the VP Wasm module. The memory is now correctly freed after the test logic has completed, preventing the leak.